### PR TITLE
Only do Cloudflare script stuff on frontend

### DIFF
--- a/Broadstreet/Core.php
+++ b/Broadstreet/Core.php
@@ -460,8 +460,12 @@ class Broadstreet_Core
      */
     public function finalizeZoneTag($tag, $handle = '', $src = false)
     {
+        if (is_admin()) {
+            return $tag;
+        }
+
         // add cloudflare attrs. but seriously, f cloudflare
-        if (preg_match('#\/init(-2)?.min.js.*[\'"]></script>#', $tag)) {
+        if (strstr($tag, 'init-2.min.js') || strstr($tag, 'init.js')) {
             $tag = str_replace('src', "data-cfasync='false' async src", $tag);
         }
 

--- a/Broadstreet/Core.php
+++ b/Broadstreet/Core.php
@@ -461,7 +461,7 @@ class Broadstreet_Core
     public function finalizeZoneTag($tag, $handle = '', $src = false)
     {
         // add cloudflare attrs. but seriously, f cloudflare
-        if (strstr($tag, 'init-2.min.js') || strstr($tag, 'init.js')) {
+        if (preg_match('#\/init(-2)?.min.js.*[\'"]></script>#', $tag)) {
             $tag = str_replace('src', "data-cfasync='false' async src", $tag);
         }
 


### PR DESCRIPTION
Closes #9 

Originally I had [an improved regex that would only match your scripts](https://github.com/claudiulodro/broadstreet-wp/commit/7e634c78579a02d6a992c3a5dfeb04402f395716) in the `finalizeZoneTag` check, but I think this proposed approach is going to be simpler and more robust. Your scripts [only get loaded on the frontend](https://github.com/broadstreetads/broadstreet-wp/blob/master/Broadstreet/Core.php#L480), so this change shouldn't cause any issues.

To test:
- Follow instructions to reproduce error in #9 
- Apply patch.
- In the source code while editing a post you should see something like `<script type='text/javascript' src='http://newspack.test/wp-includes/js/api-request.js?ver=5.2.2'></script>`
- On the frontend source code you should see something like `<script type='text/javascript' data-cfasync='false' async src='//cdn.broadstreetads.com/init-2.min.js?ver=5.2.2'></script>`
 

