### PR TITLE
Add AMP-compatibility

### DIFF
--- a/Broadstreet/Utility.php
+++ b/Broadstreet/Utility.php
@@ -65,6 +65,10 @@ class Broadstreet_Utility
      * @return type
      */
     public static function getZoneCode($id, $attrs = array()) {
+        if ( self::isAMPEndpoint() ) {
+            return self::getAMPZoneCode($id);
+        }
+
         $placement_settings = Broadstreet_Utility::getPlacementSettings();
 
         $old = false;
@@ -96,6 +100,27 @@ class Broadstreet_Utility
 
             return "<broadstreet-zone $attr_string></broadstreet-zone>";
         }
+    }
+
+    /**
+     * Get AMPHTML code for a specific zone 
+     * @param type $id
+     * @return string
+     */
+    public static function getAMPZoneCode($id) {
+        $network_id = (int) self::getNetworkId();
+        $zone_id = (int) $id;
+        $keywords = esc_attr(Broadstreet_Utility::getAllAdKeywordsString(true));
+
+        /**
+         * @todo The height and width of the ad zones should be dynamic because the ad size is unknown until the ad has loaded. 
+         * Currently e.g. a 900x70 ad will display in a 300:250 ratio container which means a lot of extra white space.
+         * Something similar to amp-iframe's resizable attribute might work, but doesn't appear to be a supported feature of amp-ad.
+         */
+        $width = 300;
+        $height = 250;
+
+        return "<amp-ad type='broadstreetads' layout='responsive' width='$width' height='$height' data-network='$network_id' data-zone='$zone_id' data-keywords='$keywords'></amp-ad>";
     }
 
     /**
@@ -1126,8 +1151,15 @@ class Broadstreet_Utility
      * Return a unique identifier for the site for use with future help requests
      * @return string A unique identifier
      */
-    public static function getServiceTag()
-    {
+    public static function getServiceTag() {
         return md5($report['u'] = get_bloginfo('url'));
+    }
+
+    /**
+     * Return whether an AMP page is requested.
+     * @return bool True if AMP
+     */
+    public static function isAMPEndpoint() {
+        return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
     }
 }

--- a/Broadstreet/Utility.php
+++ b/Broadstreet/Utility.php
@@ -65,7 +65,7 @@ class Broadstreet_Utility
      * @return type
      */
     public static function getZoneCode($id, $attrs = array()) {
-        if ( self::isAMPEndpoint() ) {
+        if (self::isAMPEndpoint()) {
             return self::getAMPZoneCode($id);
         }
 
@@ -1160,6 +1160,6 @@ class Broadstreet_Utility
      * @return bool True if AMP
      */
     public static function isAMPEndpoint() {
-        return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+        return function_exists('is_amp_endpoint') && is_amp_endpoint();
     }
 }


### PR DESCRIPTION
### Description

This PR has most of the required work to add AMP-compatibility to Broadstreet Ads zones. Currently this plugin has no AMP-compatibility, as the script tags get stripped out in AMP mode resulting in no ads rendered.

The plugin will now output AMP-compatible versions of existing, configured ad zones on AMP pages, and regular versions on regular pages. The idea is that the same zone will work great in both AMP and non-AMP modes.

There is one main issue I haven't quite solved yet around sizing of the ad zones in AMP. I've opened the PR in this state so that we can discuss the best approach, and will update it once that's figured out.

### To test:

0. Install and activate the official [AMP plugin](https://wordpress.org/plugins/amp/). For testing, it's easiest if you set the Website Mode in WP-Admin > AMP > General to 'Transitional' mode.
1. Set up Broadstreet Ads plugin with a couple ad zones:
<img width="410" alt="Screen Shot 2019-09-15 at 4 29 41 PM" src="https://user-images.githubusercontent.com/7317227/64927249-44473000-d7d6-11e9-9721-3503e9101dc8.png">
<img width="320" alt="Screen Shot 2019-09-15 at 4 29 52 PM" src="https://user-images.githubusercontent.com/7317227/64927251-4dd09800-d7d6-11e9-8be6-697d45697b8f.png">
2. View the site frontend in AMP and non-AMP mode. You should see the same ad zones in both:

**Non-AMP version:**

<img width="529" alt="Screen Shot 2019-09-15 at 4 35 53 PM" src="https://user-images.githubusercontent.com/7317227/64927299-f979e800-d7d6-11e9-9554-da481596586b.png">

**AMP version:**

<img width="542" alt="Screen Shot 2019-09-15 at 4 36 09 PM" src="https://user-images.githubusercontent.com/7317227/64927301-00a0f600-d7d7-11e9-9cf8-d6320e738eff.png">

### Next step:

As you can see in the screenshots and [this docblock comment](https://github.com/broadstreetads/broadstreet-wp/compare/master...claudiulodro:master?expand=1#diff-f6e8b291b0f985d67e95ee4a133941ddR116), the AMP-version has issues with the amount of padding on ads that aren't 300:250 ratio. 

Ideally those heights would be dynamic since ads of different sizes can load in the zone. I have some proposed ideas, let me know if any are feasible or please suggest alternate approaches:
- If there was a way to programmatically get the height and width of the ad zone using PHP, it could just be set with correct values. I didn't see any way to access that information from within the Broadstreet WP plugin, though.
- Instead of rendering the same zone for both AMP and non-AMP modes, there could be AMP and non-AMP zones, with the AMP zones having a defined height and width. This seems like it would introduce complexity when setting up ad zones, though.
- Maybe something like [the amp-iframe resizable attribute](https://amp.dev/documentation/examples/components/amp-iframe/#resizable-iframe) is possible for amp-ads, and they could be resized dynamically after the ad has loaded. Perhaps that could be added in the [Broadstreet amp-ad implementation](https://github.com/ampproject/amphtml/blob/master/ads/broadstreetads.md)?

If the sizing issue can be solved, this would be a great way to add AMP-support to the plugin without changing the workflow of the people managing the ads. Let me know if you have any thoughts or ideas on any of this. Thanks!