### PR TITLE
Use zone width/heights when rendering AMP ad

### DIFF
--- a/Broadstreet/Utility.php
+++ b/Broadstreet/Utility.php
@@ -112,13 +112,28 @@ class Broadstreet_Utility
         $zone_id = (int) $id;
         $keywords = esc_attr(Broadstreet_Utility::getAllAdKeywordsString(true));
 
-        /**
-         * @todo The height and width of the ad zones should be dynamic because the ad size is unknown until the ad has loaded. 
-         * Currently e.g. a 900x70 ad will display in a 300:250 ratio container which means a lot of extra white space.
-         * Something similar to amp-iframe's resizable attribute might work, but doesn't appear to be a supported feature of amp-ad.
-         */
+        // AMP ads require defined width and heights. Use standard 300x250 ad size as the default.
         $width = 300;
         $height = 250;
+
+        $zones = self::getZoneCache();
+        if (isset($zones[$zone_id])) {
+            $zone = $zones[$zone_id];
+
+            if (property_exists($zone, 'width') && !empty($zone->width)) {
+                $parsed_width = intval($zone->width);
+                if ($parsed_width) {
+                    $width = $parsed_width;
+                }
+            }
+
+            if (property_exists($zone, 'height') && !empty($zone->height)) {
+                $parsed_height = intval($zone->height);
+                if ($parsed_height) {
+                    $height = $parsed_height;
+                }
+            }
+        }
 
         return "<amp-ad type='broadstreetads' layout='responsive' width='$width' height='$height' data-network='$network_id' data-zone='$zone_id' data-keywords='$keywords'></amp-ad>";
     }


### PR DESCRIPTION
This is a continuation of the work and discussion from https://github.com/broadstreetads/broadstreet-wp/pull/11. 

I have updated the AMP-rendering code to use the zone's width and height when available. When it's not available, it'll default to the standard 300x250 size on AMP. 

It doesn't look like [this ad has defined width/height yet](https://github.com/broadstreetads/broadstreet-wp/pull/11#issuecomment-537191695), so I haven't been able to test with a "real" width/height (I can see `null` for the width/height response in the API, though, so it should be working correctly on the Broadstreet side). I'm not sure the exact format of the API response, but this PR should work for numbers (`728`), numeric strings (`'728'`), and pixel strings (`'728px'`). If the values aren't in one of those formats, please let me know.

cc @katzgrau 