### PR TITLE
Fix PHP warning in Utility.php

### DIFF
--- a/Broadstreet/Utility.php
+++ b/Broadstreet/Utility.php
@@ -1114,7 +1114,13 @@ class Broadstreet_Utility
                 }
             }
 
-            $slugs[] = $post->post_name;
+            if (is_a($post, 'WP_Post')) {
+                $slugs[] = $post->post_name;
+            } elseif (is_array($post)) {
+                if (isset($post['post_name'])){
+                    $slugs[] = $post['post_name'];
+                }
+            }
             $slugs[] = get_post_type();
         }
 


### PR DESCRIPTION
Fixes warning generated when page have not reset query after looping through separate query.

Fixes https://github.com/broadstreetads/broadstreet-wp/issues/19