### PR TITLE
Add a hook to watch for scheduled posts going live to update the perm…

### DIFF
--- a/Broadstreet/Config.php
+++ b/Broadstreet/Config.php
@@ -140,4 +140,4 @@ class Broadstreet_Config
     }
 }
 
-define('BROADSTREET_VERSION', '1.46.3');
+define('BROADSTREET_VERSION', '1.46.4');

--- a/Broadstreet/Core.php
+++ b/Broadstreet/Core.php
@@ -157,7 +157,8 @@ class Broadstreet_Core
         add_filter('comments_template', array($this, 'addAdsBeforeComments'), 20);
 
         if (Broadstreet_Utility::getOption(self::KEY_API_KEY)) {
-            add_action('post_updated', array($this, 'saveSponsorPostMeta'), 20);
+			add_action('post_updated', array($this, 'saveSponsorPostMeta'), 20);
+			add_action('transition_post_status', array($this, 'monitorForScheduledPostStatus'), 20, 10, 3);
         }
 
         add_action('post_updated', array($this, 'saveAdVisibilityMeta'), 20);
@@ -1086,6 +1087,19 @@ class Broadstreet_Core
             }
         }
     }
+
+	/**
+	 * Handler for saving sponsor-specific meta data for scheduled posts. Scheduled posts sometimes don't have the correct permalink
+	 * so this checks everytime a post's status is updated to `published` and executes an update to reflect the proper permalink in Broadstreet.
+	 * @param type $new_status The new status of the post
+	 * @param type $old_status The previous status of the post
+	 * @param type $post The post
+	 */
+	public function monitorForScheduledPostStatus($new_status, $old_status, $post) {
+        if (($old_status != 'publish') && ($new_status == 'publish')) {
+            $this->saveSponsorPostMeta($post->ID);
+        }
+	}
 
     /**
      * Handler for saving sponsor-specific meta data

--- a/broadstreet.php
+++ b/broadstreet.php
@@ -3,7 +3,7 @@
 Plugin Name: Broadstreet
 Plugin URI: http://broadstreetads.com
 Description: Integrate Broadstreet business directory and adserving power into your site
-Version: 1.46.3
+Version: 1.46.4
 Tested up to: 6.1
 Author: Broadstreet
 Author URI: http://broadstreetads.com

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Broadstreet
 Tags: broadstreet,local,publishers,hyperlocal,independent,news,business,directory
 Requires at least: 3.0
 Tested up to: 6.3
-Stable tag: 1.46.3
+Stable tag: 1.46.4
 
 Integrate Broadstreet adserving power into your site.
 


### PR DESCRIPTION
…alink on Broadstreet.

When saving an ad the permalink that gets saved: ?p=POSTID. Doesn't match what people actually visit therefore resulting in broken sponsored content stats.

This is the fix so that when a scheduled post ends up going live (We will then finally have the permalink), we execute to.

Simply scheduling a post to go live doesn't execute the update hook. And even if we included a specific hook the permalink still comes back as ?p=$POSTID, which is why I solved it this way.