### PR TITLE
Add/custom zone selector

### DIFF
--- a/Broadstreet/Config.php
+++ b/Broadstreet/Config.php
@@ -140,4 +140,4 @@ class Broadstreet_Config
     }
 }
 
-define('BROADSTREET_VERSION', '1.51.2');
+define('BROADSTREET_VERSION', '1.51.3');

--- a/Broadstreet/Core.php
+++ b/Broadstreet/Core.php
@@ -1272,6 +1272,45 @@ class Broadstreet_Core
         {
             foreach(self::$_businessDefaults as $key => $value)
             {
+                // Special handling for video content - only allow video and iframe tags to prevent XSS attacks
+                if(isset($_POST[$key]) && $key == 'bs_video') {
+                    // Create a whitelist of allowed tags
+                    $allowed_tags = array(
+                        'video' => array(
+                            'width' => true,
+                            'height' => true,
+                            'controls' => true,
+                            'autoplay' => true,
+                            'loop' => true,
+                            'muted' => true,
+                            'poster' => true,
+                            'preload' => true,
+                            'src' => true
+                        ),
+                        'source' => array(
+                            'src' => true,
+                            'type' => true
+                        ),
+                        'iframe' => array(
+                            'src' => true,
+                            'width' => true,
+                            'height' => true,
+                            'frameborder' => true,
+                            'allowfullscreen' => true,
+                            'allow' => true
+                        )
+                    );
+                    
+                    // Strip all tags except those in the whitelist
+                    $video_content = wp_kses($_POST[$key], $allowed_tags);
+                    
+                    // Save the sanitized video content
+                    Broadstreet_Utility::setPostMeta($post_id, $key, $video_content);
+                    
+                    // Skip the default handling for this field
+                    continue;
+                }
+
                 if(isset($_POST[$key]))
                     Broadstreet_Utility::setPostMeta($post_id, $key, is_string($_POST[$key]) ? trim($_POST[$key]) : $_POST[$key]);
                 elseif($key == 'bs_images')

--- a/Broadstreet/Utility.php
+++ b/Broadstreet/Utility.php
@@ -50,6 +50,11 @@ class Broadstreet_Utility
             if (property_exists($placement_settings, 'cdn_whitelabel') && strlen($placement_settings->adserver_whitelabel) > 0) {
                 $args->domain = $placement_settings->adserver_whitelabel;
             }
+
+            if (property_exists($placement_settings, 'custom_selector') && strlen($placement_settings->custom_selector) > 0) {
+                $args->selector = $placement_settings->custom_selector;
+            }
+            
             $args = json_encode($args);
         }
 
@@ -200,7 +205,13 @@ class Broadstreet_Utility
                     return $key.'="'.esc_attr($attrs[$key]).'"';
                 }, array_keys($attrs)));
 
-            return "<broadstreet-zone $attr_string></broadstreet-zone>";
+            // Check if a custom selector is defined in placement settings
+            $selector = 'broadstreet-zone';
+            if (property_exists($placement_settings, 'custom_selector') && !empty($placement_settings->custom_selector)) {
+                $selector = esc_attr($placement_settings->custom_selector);
+            }
+
+            return "<$selector $attr_string></$selector>";
         }
     }
 

--- a/Broadstreet/Views/admin/zones.php
+++ b/Broadstreet/Views/admin/zones.php
@@ -269,6 +269,21 @@
                     <div class="option">
                         <div class="control-label">
                             <div class="name nomargin">
+                                Custom Selector
+                            </div>
+                            <div class="desc nomargin">
+                                If provided, this will replace the default 'broadstreet-zone' tag in ad code.
+                            </div>
+                        </div>
+                        <div class="control-container">
+                            <input ng-model="data.positions_zones.custom_selector" type="text" placeholder="broadstreet-zone" />
+                        </div>
+                        <div style="clear:both;"></div>
+                    </div>
+                    <div class="break"></div>
+                    <div class="option">
+                        <div class="control-label">
+                            <div class="name nomargin">
                                 Ad Tag Init Arguments (Optional, JSON)
                             </div>
                             <div class="desc nomargin">

--- a/broadstreet.php
+++ b/broadstreet.php
@@ -3,7 +3,7 @@
 Plugin Name: Broadstreet
 Plugin URI: http://broadstreetads.com
 Description: Integrate Broadstreet business directory and adserving power into your site
-Version: 1.51.2
+Version: 1.51.3
 Tested up to: 6.6.1
 Author: Broadstreet
 Author URI: http://broadstreetads.com

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Broadstreet
 Tags: broadstreet,local,publishers,hyperlocal,independent,news,business,directory
 Requires at least: 3.0
 Tested up to: 6.7.1
-Stable tag: 1.51.2
+Stable tag: 1.51.3
 
 Integrate Broadstreet adserving power into your site.
 


### PR DESCRIPTION
Added the ability to quickly and easily change all the zone selectors through a single text field in the zone options.

Needed to ensure whitelabeling still works when ad blockers target the `broadstreet-zone` element.