### PR TITLE
Fix Settings CSRF

### DIFF
--- a/Broadstreet/Ajax.php
+++ b/Broadstreet/Ajax.php
@@ -19,6 +19,16 @@ class Broadstreet_Ajax
      */
     public static function saveSettings()
     {
+        // Verify nonce to prevent CSRF attacks
+        if (!wp_verify_nonce($_POST['_wpnonce'], 'bs_save_settings_nonce')) {
+            die(json_encode(array('success' => false, 'message' => 'Security check failed. Please refresh the page and try again.')));
+        }
+        
+        // Check user capabilities
+        if (!current_user_can('manage_options')) {
+            die(json_encode(array('success' => false, 'message' => 'You do not have permission to perform this action.')));
+        }
+        
         // Sanitize the API key before storing it
         $api_key = sanitize_text_field($_POST['api_key']);
         Broadstreet_Utility::setOption(Broadstreet_Core::KEY_API_KEY, $api_key);

--- a/Broadstreet/Public/js/broadstreet.js
+++ b/Broadstreet/Public/js/broadstreet.js
@@ -46,16 +46,17 @@ jQuery(function($){
 
         var network_id = $('#network').val();
 
-        jQuery.post(ajaxurl, {
-             action: 'bs_save_settings',
-             api_key: $('#api_key').val(),
-             business_enabled: $('#business_enabled').is(':checked'),
-             network_id: network_id
+        jQuery.post(
+            ajaxurl, {
+                action: 'bs_save_settings',
+                api_key: $('#api_key').val(),
+                business_enabled: $('#business_enabled').is(':checked'),
+                network_id: network_id,
+                _wpnonce: $('input[name="_wpnonce"]').val()
             },
             function(response) {
                 if (console) console.log(response);
-                if(response.success)
-                {
+                if(response.success) {
                     markSaved('#save-success');
                     $('#network').empty();
 
@@ -86,12 +87,18 @@ jQuery(function($){
                         alert(response.message);
                     }
 
-                    if(needRefresh) {
-                        location.reload();
-                    }
+                     if(needRefresh) {
+                         location.reload();
+                     }
+                } else {
+                    // Show error message if save failed
+                    alert('Save failed: ' + (response.message || 'Unknown error'));
                 }
             },
-        'json');
+            'json').fail(function(xhr, status, error) {
+                console.error('AJAX Error:', status, error);
+                alert('Network error occurred. Please try again.');
+            });
     });
 
 
@@ -101,10 +108,10 @@ jQuery(function($){
         var el = $(e.target);
         var name = el.attr('data-name');
 
-        $.post(ajaxurl, {
-            action: 'create_advertiser',
-            name: name
-        }, function(response) {
+         $.post(ajaxurl, {
+             action: 'create_advertiser',
+             name: name
+         }, function(response) {
             console.log(response);
             if(response.success) {
 

--- a/Broadstreet/Views/admin/admin.php
+++ b/Broadstreet/Views/admin/admin.php
@@ -91,6 +91,7 @@
                         <div class="save-container">
                             <span class="success" id="save-success">Saved!</span>
                             <input id="save-broadstreet" type="button" value="Save" name="" />
+                            <input type="hidden" name="_wpnonce" value="<?php echo wp_create_nonce('bs_save_settings_nonce'); ?>" />
                         </div>
                     </div>
                     <div class="clearfix"></div>


### PR DESCRIPTION
This adds the wp_verify_nonce to check for the `wp_nonce` token in the form to prevent the csrf attack.