### PR TITLE
Add broadstreet_ad_keywords filter for custom keyword targeting

### DIFF
--- a/Broadstreet/Utility.php
+++ b/Broadstreet/Utility.php
@@ -1240,6 +1240,9 @@ class Broadstreet_Utility
             $keywords[] = $slug;
         }
 
+        // Allow developers to add custom keywords
+        $keywords = apply_filters('broadstreet_ad_keywords', $keywords);
+
         if ($omit_quotes) {
             $keywords_string = implode(",", $keywords);
         } else {

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,35 @@ Publishers into your Broadstreet site.
 To learn more about Broadstreet, and how it can help you as a local publisher,
 send an email to [frontdesk@broadstreetads.com](frontdesk@broadstreetads.com).
 
+**Developer Hooks**
+
+The plugin provides filters for developers to customize behavior:
+
+`broadstreet_ad_keywords` - Filter the keywords sent to the ad server for targeting
+
+Example usage:
+
+```php
+add_filter( 'broadstreet_ad_keywords', function( $keywords ) {
+    // Add logged-in status
+    if ( is_user_logged_in() ) {
+        $keywords[] = 'user_logged_in';
+    }
+
+    // Add custom taxonomy terms
+    if ( is_singular() ) {
+        $terms = get_the_terms( get_the_ID(), 'my_custom_taxonomy' );
+        if ( $terms && ! is_wp_error( $terms ) ) {
+            foreach ( $terms as $term ) {
+                $keywords[] = $term->name;
+            }
+        }
+    }
+
+    return $keywords;
+} );
+```
+
 **How can I report security bugs?**
 
 You can report security bugs through the Patchstack Vulnerability Disclosure


### PR DESCRIPTION
## Summary

Adds a new `broadstreet_ad_keywords` filter that allows external developers to inject custom keywords into the ad targeting system.

## Changes

- Added `apply_filters('broadstreet_ad_keywords', $keywords)` in `Broadstreet_Utility::getAllAdKeywordsString()` (line 1244)
- Updated `readme.txt` with developer hooks documentation and usage examples

## Use Cases

This filter enables developers to:
- Add logged-in/logged-out user status keywords
- Include custom taxonomy terms for ad targeting
- Add any contextual keywords based on site-specific logic

## Example Usage

```php
add_filter( 'broadstreet_ad_keywords', function( $keywords ) {
    if ( is_user_logged_in() ) {
        $keywords[] = 'user_logged_in';
    }
    
    if ( is_singular() ) {
        $terms = get_the_terms( get_the_ID(), 'my_custom_taxonomy' );
        if ( $terms && ! is_wp_error( $terms ) ) {
            foreach ( $terms as $term ) {
                $keywords[] = $term->name;
            }
        }
    }
    
    return $keywords;
} );
```

## Testing

Tested by adding custom keywords via the filter and verifying they appear in the `window.broadstreetKeywords` array and are properly sent to the ad server.