### PR TITLE
Add filters for meta box post types and placement (1.53.2)

### DIFF
--- a/Broadstreet/Config.php
+++ b/Broadstreet/Config.php
@@ -140,4 +140,4 @@ class Broadstreet_Config
     }
 }
 
-define('BROADSTREET_VERSION', '1.53.1');
+define('BROADSTREET_VERSION', '1.53.2');

--- a/Broadstreet/Core.php
+++ b/Broadstreet/Core.php
@@ -465,7 +465,14 @@ class Broadstreet_Core
             'page'
         );
 
-        $screens = get_post_types();
+        /**
+         * Filter the post types on which Broadstreet meta boxes appear.
+         * Defaults to all registered post types.
+         *
+         * @param array $post_types Array of post type slugs.
+         */
+        $screens = apply_filters('broadstreet_meta_box_post_types', get_post_types());
+
         if (Broadstreet_Utility::getOption(self::KEY_API_KEY)) {
             foreach ( $screens as $screen ) {
                 add_meta_box(
@@ -473,8 +480,8 @@ class Broadstreet_Core
                     __( '<span class="dashicons dashicons-performance"></span> Sponsored Content', 'broadstreet_textdomain'),
                     array($this, 'broadstreetSponsoredBox'),
                     $screen,
-                    'side',
-                    'high'
+                    apply_filters('broadstreet_sponsored_meta_box_context', 'side', $screen),
+                    apply_filters('broadstreet_sponsored_meta_box_priority', 'high', $screen)
                 );
             }
         }
@@ -485,7 +492,8 @@ class Broadstreet_Core
                 __( '<span class="dashicons dashicons-format-image"></span> Broadstreet Options', 'broadstreet_textdomain'),
                 array($this, 'broadstreetAdVisibilityBox'),
                 $screen,
-                'side'
+                apply_filters('broadstreet_options_meta_box_context', 'side', $screen),
+                apply_filters('broadstreet_options_meta_box_priority', 'default', $screen)
             );
         }
 
@@ -496,7 +504,8 @@ class Broadstreet_Core
                 __( 'Business Details', 'broadstreet_textdomain'),
                 array($this, 'broadstreetBusinessBox'),
                 self::BIZ_POST_TYPE,
-                'normal'
+                apply_filters('broadstreet_business_meta_box_context', 'normal'),
+                apply_filters('broadstreet_business_meta_box_priority', 'default')
             );
         }
     }

--- a/broadstreet.php
+++ b/broadstreet.php
@@ -3,7 +3,7 @@
 Plugin Name: Broadstreet
 Plugin URI: http://broadstreetads.com
 Description: Integrate Broadstreet business directory and adserving power into your site
-Version: 1.53.1
+Version: 1.53.2
 Tested up to: 6.9
 Author: Broadstreet
 Author URI: http://broadstreetads.com

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: Broadstreet
 Tags: broadstreet,local,publishers,hyperlocal,independent,news,business,directory
 Requires at least: 3.0
 Tested up to: 6.9
-Stable tag: 1.53.1
+Stable tag: 1.53.2
 
 Integrate Broadstreet adserving power into your site.
 


### PR DESCRIPTION
## Summary
- Adds `broadstreet_meta_box_post_types` filter so devs can limit which post types receive Broadstreet meta boxes (resolves Matt Pramschufer's request)
- Adds `broadstreet_sponsored_meta_box_context` / `_priority`, `broadstreet_options_meta_box_context` / `_priority`, and `broadstreet_business_meta_box_context` / `_priority` filters so the Sponsored Content, Broadstreet Options, and Business Details boxes can be repositioned without patching the plugin
- Bumps version to 1.53.2 in `broadstreet.php`, `readme.txt`, and `Broadstreet/Config.php`

Defaults preserve current behavior: Sponsored Content remains `side`/`high`, Broadstreet Options remains `side`/`default`, Business Details remains `normal`/`default`.

## Test plan
- [ ] Activate plugin on a test site; confirm meta boxes appear in the same locations as 1.53.1 with no filters applied
- [ ] Hook `broadstreet_meta_box_post_types` to return `['post']` and confirm boxes are hidden on Pages
- [ ] Hook `broadstreet_business_meta_box_context` to return `'side'` and confirm Business Details moves to the right column

🤖 Generated with [Claude Code](https://claude.com/claude-code)
